### PR TITLE
Allow id_token to be optional for OAuth2Token.update_token

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -127,6 +127,23 @@ def oauth2_token(
         "token_type": "Bearer",
     }
 
+@pytest.fixture()
+def oauth2_token_without_id_token(
+    xero_access_token,
+    xero_refresh_token,
+    xero_scope,
+    xero_expires_in,
+    xero_expires_at,
+):
+    return {
+        "access_token": xero_access_token,
+        "expires_at": xero_expires_at,
+        "expires_in": xero_expires_in,
+        "refresh_token": xero_refresh_token,
+        "scope": xero_scope,
+        "token_type": "Bearer",
+    }
+
 
 @pytest.fixture()
 def oauth2_refresh_token(oauth2_token, xero_refresh_token):

--- a/tests/test_api_client/test_oauth2.py
+++ b/tests/test_api_client/test_oauth2.py
@@ -205,6 +205,22 @@ def test_auth2_call_refresh_token_api(oauth2_refresh_token):
     assert call_kwargs == {}
     assert new_token is token
 
+def test_auth2_call_refresh_token_api_without_id_token(oauth2_token_without_id_token):
+    # Given valid refresh token and client credentials without using OpenID scope (id_token absent)
+    oauth2_token = OAuth2Token()
+    oauth2_token.update_token(**oauth2_token_without_id_token)
+    token = {}
+    token_api = FakeClass()
+    token_api.refresh_token = FakeMethod(return_value=token)
+    # When refresh token API endpoint called
+    new_token = oauth2_token.call_refresh_token_api(token_api)
+    # Then new oauth2 token received
+    assert len(token_api.refresh_token.calls) == 1
+    call_args, call_kwargs = token_api.refresh_token.calls[0]
+    assert call_args == (oauth2_token.refresh_token, oauth2_token.scope)
+    assert call_kwargs == {}
+    assert new_token is token
+
 
 def test_token_api_refresh_token(
     xero_client_id, xero_client_secret, xero_scope, vcr, vcr_cassette_name

--- a/xero_python/api_client/oauth2.py
+++ b/xero_python/api_client/oauth2.py
@@ -179,7 +179,7 @@ class OAuth2Token:
         expires_at,
         expires_in,
         token_type,
-        id_token,
+        id_token=None,
     ):
         """
         Set new auth2 token details
@@ -189,7 +189,7 @@ class OAuth2Token:
         :param expires_at: float timestamp
         :param expires_in: number
         :param token_type: str
-        :param id_token: str
+        :param id_token: str (optional)
         """
         self.access_token = access_token
         self.expires_at = expires_at


### PR DESCRIPTION
Fixes https://github.com/XeroAPI/xero-python/issues/27

The "id_token" key is not present when the the `openid` scope is not used. This especially problematic when migration from OAuth1, since the `openid` scope is not allowed during the migration.
