### PR TITLE
Add employer_tax_lines in payroll

### DIFF
--- a/xero_python/payrolluk/models/payslip.py
+++ b/xero_python/payrolluk/models/payslip.py
@@ -57,6 +57,7 @@ class Payslip(BaseModel):
         "benefit_lines": "list[BenefitLine]",
         "payment_lines": "list[PaymentLine]",
         "employee_tax_lines": "list[TaxLine]",
+        "employer_tax_lines": "list[TaxLine]",
         "court_order_lines": "list[CourtOrderLine]",
     }
 
@@ -87,6 +88,7 @@ class Payslip(BaseModel):
         "benefit_lines": "benefitLines",
         "payment_lines": "paymentLines",
         "employee_tax_lines": "employeeTaxLines",
+        "employer_tax_lines": "employerTaxLines",
         "court_order_lines": "courtOrderLines",
     }
 
@@ -118,6 +120,7 @@ class Payslip(BaseModel):
         benefit_lines=None,
         payment_lines=None,
         employee_tax_lines=None,
+        employer_tax_lines=None,
         court_order_lines=None,
     ):  # noqa: E501
         """Payslip - a model defined in OpenAPI"""  # noqa: E501
@@ -148,6 +151,7 @@ class Payslip(BaseModel):
         self._benefit_lines = None
         self._payment_lines = None
         self._employee_tax_lines = None
+        self._employer_tax_lines = None
         self._court_order_lines = None
         self.discriminator = None
 
@@ -203,6 +207,8 @@ class Payslip(BaseModel):
             self.payment_lines = payment_lines
         if employee_tax_lines is not None:
             self.employee_tax_lines = employee_tax_lines
+        if employer_tax_lines is not None:
+            self.employer_tax_lines = employer_tax_lines
         if court_order_lines is not None:
             self.court_order_lines = court_order_lines
 
@@ -781,6 +787,15 @@ class Payslip(BaseModel):
         :rtype: list[TaxLine]
         """
         return self._employee_tax_lines
+    @property
+    def employer_tax_lines(self):
+        """Gets the employer_tax_lines of this Payslip.  # noqa: E501
+
+
+        :return: The employer_tax_lines of this Payslip.  # noqa: E501
+        :rtype: list[TaxLine]
+        """
+        return self._employer_tax_lines
 
     @employee_tax_lines.setter
     def employee_tax_lines(self, employee_tax_lines):
@@ -793,6 +808,16 @@ class Payslip(BaseModel):
 
         self._employee_tax_lines = employee_tax_lines
 
+    @employer_tax_lines.setter
+    def employer_tax_lines(self, employer_tax_lines):
+        """Sets the employer_tax_lines of this Payslip.
+
+
+        :param employer_tax_lines: The employer_tax_lines of this Payslip.  # noqa: E501
+        :type: list[TaxLine]
+        """
+
+        self._employer_tax_lines = employer_tax_lines
     @property
     def court_order_lines(self):
         """Gets the court_order_lines of this Payslip.  # noqa: E501


### PR DESCRIPTION
- Add employer_tax_lines in payslip in payrolluk
xero_python/payrolluk/models/payslip.py 

Currently its having employee_tax_lines only!

