### PR TITLE
[FIX] Installation on older ubuntu systems

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ def load_requirements(file_name):
 
 
 def read_file(filename):
-    with open(filename) as fp:
+    with open(filename, encoding='utf-8') as fp:
         return fp.read()
 
 


### PR DESCRIPTION
Hey guys, hope you're good!

We've been having problems installing the latest xero-python library on some older ubuntu 18.04 servers (which, yes, need to be replaced, but are still officially supported! :P)

The error we are seeing is
```
#14 1.088 Processing /opt/odoo/xero_python-1.13.0
#14 1.089   Preparing metadata (setup.py): started
#14 1.243   Preparing metadata (setup.py): finished with status 'error'
#14 1.243   ERROR: Command errored out with exit status 1:
#14 1.243    command: /usr/bin/python3 -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/opt/odoo/xero_python-1.13.0/setup.py'"'"'; __file__='"'"'/opt/odoo/xero_python-1.13.0/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-dilm555k
#14 1.243        cwd: /opt/odoo/xero_python-1.13.0/
#14 1.243   Complete output (9 lines):
#14 1.243   Traceback (most recent call last):
#14 1.243     File "<string>", line 1, in <module>
#14 1.243     File "/opt/odoo/xero_python-1.13.0/setup.py", line 45, in <module>
#14 1.243       long_description="\n\n".join((read_file("README.md"), read_file("HISTORY.md"))),
#14 1.243     File "/opt/odoo/xero_python-1.13.0/setup.py", line 24, in read_file
#14 1.243       return fp.read()
#14 1.243     File "/usr/lib/python3.6/encodings/ascii.py", line 26, in decode
#14 1.243       return codecs.ascii_decode(input, self.errors)[0]
#14 1.243   UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 1193: ordinal not in range(128)
#14 1.243   ----------------------------------------
#14 1.243 WARNING: Discarding file:///opt/odoo/xero_python-1.13.0. Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
#14 1.243 ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```

This change fixes the error :)