### PR TITLE
Fix refresh access token silently failing when using a space delimited string for scope

### DIFF
--- a/xero_python/api_client/oauth2.py
+++ b/xero_python/api_client/oauth2.py
@@ -213,7 +213,7 @@ class OAuth2Token:
         """
         return (
             self.refresh_token
-            and isinstance(self.scope, (list, tuple))
+            and isinstance(self.scope, (list, tuple, str))
             and self.client_id
             and self.client_secret
         )

--- a/xero_python/api_client/oauth2.py
+++ b/xero_python/api_client/oauth2.py
@@ -278,6 +278,7 @@ class OAuth2Token:
         expires_at=None,
         refresh_token=None,
         id_token=None,
+        **kwargs
     ):
         """
         Set new auth2 token details


### PR DESCRIPTION
Fixes https://github.com/XeroAPI/xero-python/issues/68 

Simply extends the check for scope string to be a list, tuple, OR a string. 