### PR TITLE
build and publish wheels

### DIFF
--- a/.github/workflows/build-test-lint.yml
+++ b/.github/workflows/build-test-lint.yml
@@ -22,6 +22,7 @@ jobs:
 
             - name: Install dependencies
               run: |
+                python3 -m pip install build
                 python -m venv venv
                 source venv/bin/activate
                 pip install --upgrade pip
@@ -40,7 +41,7 @@ jobs:
               working-directory: xero-python
 
             - name: Build package
-              run: python setup.py sdist
+              run: python3 -m build
               working-directory: xero-python
 
             - name: Set up Node environment

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,7 @@ jobs:
 
             - name: Install dependencies
               run: |
+                python3 -m pip install build
                 python -m venv venv
                 source venv/bin/activate
                 pip install --upgrade pip
@@ -43,7 +44,7 @@ jobs:
                GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
             - name: Build Package
-              run: python setup.py sdist
+              run: python3 -m build
               working-directory: xero-python
 
             - name: Publish to PyPi

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@
 python-dateutil>=2.7
 urllib3
 certifi
-setuptools>=75.1.0


### PR DESCRIPTION
Direct invocation of setup.py is [deprecated](https://packaging.python.org/en/latest/discussions/setup-py-deprecated/).  setuptools dependency is not required.  Build and publish wheels.