### PR TITLE
Fix urllib3 getheaders/getheader deprecation in RESTResponse (#195)

### DIFF
--- a/tests/test_api_client/test_rest.py
+++ b/tests/test_api_client/test_rest.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for xero_python.rest.RESTResponse header access.
+
+Regression test for #195: RESTResponse must read response headers via
+``HTTPResponse.headers`` instead of the deprecated ``getheaders()`` /
+``getheader()`` accessors, which urllib3 schedules for removal.
+"""
+from urllib3.response import HTTPResponse
+
+from xero_python.rest import RESTResponse
+
+
+class _SpyResponse:
+    """Stand-in for a urllib3 response whose deprecated header accessors
+    raise if used, so the test pins RESTResponse to ``.headers``."""
+
+    def __init__(self, headers):
+        self.headers = headers
+        self.status = 200
+        self.reason = "OK"
+        self.data = b"{}"
+
+    def getheaders(self):  # pragma: no cover - must never be called
+        raise AssertionError("RESTResponse must not call deprecated getheaders()")
+
+    def getheader(self, name, default=None):  # pragma: no cover
+        raise AssertionError("RESTResponse must not call deprecated getheader()")
+
+
+def test_getheaders_returns_all_headers_without_deprecated_accessor():
+    response = RESTResponse(_SpyResponse({"Content-Type": "application/json",
+                                          "X-Custom": "value"}))
+    headers = response.getheaders()
+    assert headers["Content-Type"] == "application/json"
+    assert headers["X-Custom"] == "value"
+
+
+def test_getheader_returns_named_header_and_default_without_deprecated_accessor():
+    response = RESTResponse(_SpyResponse({"X-Custom": "value"}))
+    assert response.getheader("X-Custom") == "value"
+    assert response.getheader("Missing") is None
+    assert response.getheader("Missing", "fallback") == "fallback"
+
+
+def test_works_against_real_urllib3_response():
+    resp = HTTPResponse(
+        body=b"{}",
+        headers={"Content-Type": "application/json", "X-Custom": "value"},
+        status=200,
+        preload_content=False,
+    )
+    response = RESTResponse(resp)
+    assert response.getheaders()["X-Custom"] == "value"
+    assert response.getheader("X-Custom") == "value"
+    assert response.getheader("Missing", "fallback") == "fallback"

--- a/xero_python/rest.py
+++ b/xero_python/rest.py
@@ -45,11 +45,11 @@ class RESTResponse(io.IOBase):
 
     def getheaders(self):
         """Returns a dictionary of the response headers."""
-        return self.urllib3_response.getheaders()
+        return self.urllib3_response.headers
 
     def getheader(self, name, default=None):
         """Returns a given response header."""
-        return self.urllib3_response.getheader(name, default)
+        return self.urllib3_response.headers.get(name, default)
 
 
 class RESTClientObject(object):


### PR DESCRIPTION
## Fixes #195

`urllib3` deprecated `HTTPResponse.getheaders()` and `HTTPResponse.getheader()` in favour of accessing `HTTPResponse.headers` directly, and has scheduled them for removal. `RESTResponse` wrapped those deprecated accessors, so every response emitted a `DeprecationWarning` and the SDK would break once urllib3 drops them.

### Change
`RESTResponse` now reads headers via `.headers` / `.headers.get(name, default)`:

```python
def getheaders(self):
    return self.urllib3_response.headers

def getheader(self, name, default=None):
    return self.urllib3_response.headers.get(name, default)
```

This is behaviour-preserving — in urllib3 2.x `getheaders()` returns `self.headers` and `getheader(name, default)` returns `self.headers.get(name, default)`. The **public** `RESTResponse.getheaders()`/`getheader()` methods are unchanged, so the call sites in `api_client/__init__.py` and `exceptions/__init__.py` keep working.

### Tests
Added `tests/test_api_client/test_rest.py` with version-independent regression tests: a spy response whose deprecated accessors raise if called, plus a check against a real urllib3 `HTTPResponse`. The spy tests fail on the old code and pass on the fix. Full `test_api_client` suite (150 tests) stays green.

---
*AI-assisted, human-reviewed — I'm an AI engineer; I find, fix, and test with AI, then review and verify before opening.*