### PR TITLE
Serialize UUID values instead of raising ValueError (#161)

### DIFF
--- a/tests/test_api_client/test_serializer.py
+++ b/tests/test_api_client/test_serializer.py
@@ -3,6 +3,7 @@ from contextlib import contextmanager
 from datetime import date, datetime, timedelta
 from decimal import Decimal
 from unittest import mock
+from uuid import UUID
 
 import pytest
 from dateutil import tz
@@ -389,3 +390,14 @@ def test_serialize_enum_model(value, expected):
     # then correct enum value expected
     assert isinstance(result, str)
     assert result == expected
+
+
+# serialize UUID tests (regression for #161)
+def test_serialize_uuid():
+    # given a UUID value (e.g. an invoice id returned by the Xero API)
+    value = UUID("12345678-1234-5678-1234-567812345678")
+    # when serializing it
+    result = serialize(value)
+    # then it becomes the canonical hyphenated string, not a ValueError
+    assert isinstance(result, str)
+    assert result == "12345678-1234-5678-1234-567812345678"

--- a/xero_python/api_client/serializer.py
+++ b/xero_python/api_client/serializer.py
@@ -3,6 +3,7 @@ import re
 from datetime import datetime, time, date
 from enum import Enum
 from functools import singledispatch
+from uuid import UUID
 
 from dateutil import tz
 
@@ -221,3 +222,15 @@ def serialize_enum_model(model):
     :return: serialized object
     """
     return model.value
+
+
+@serialize_model.register(UUID)
+def serialize_uuid_model(model):
+    """Serializes a UUID into a json serializable string.
+
+    Uses the canonical 8-4-4-4-12 hyphenated form expected by the Xero API.
+
+    :param model: UUID instance to serialize
+    :return: serialized object
+    """
+    return str(model)


### PR DESCRIPTION
## Fixes #161

Calling e.g. `accounting_api.get_invoice(...)` can raise:

```
ValueError: Can't serialize value type 'UUID'
```

The `singledispatch` serializer in `serializer.py` has handlers for `BaseModel` and `Enum` but none for `uuid.UUID`, so any value that is a `UUID` (such as an invoice id) falls through to the default and raises.

### Change
Register a `UUID` handler on `serialize_model`:

```python
@serialize_model.register(UUID)
def serialize_uuid_model(model):
    return str(model)
```

I used `str(model)` (canonical `8-4-4-4-12` hyphenated form, e.g. `12345678-1234-5678-1234-567812345678`) rather than the `.hex` form suggested in #93, because that is the GUID format the Xero API uses and accepts.

### Test
Added `test_serialize_uuid` in `tests/test_api_client/test_serializer.py`. It fails on `master` (ValueError) and passes with the fix. Full `test_api_client` suite (151 tests) stays green.

> Note: the related `to_dict()` path raised the same way for enums/UUIDs — fixed separately in #227.

---
*AI-assisted, human-reviewed — I'm an AI engineer; I find, fix, and test with AI, then review and verify before opening.*