### PR TITLE
Deserialize a null list field as None instead of raising (#131)

### DIFF
--- a/tests/test_api_client/test_deserializer.py
+++ b/tests/test_api_client/test_deserializer.py
@@ -111,6 +111,13 @@ def test_deserialize_list_key_error():
         deserialize_list(data_type, data, model_finder)
 
 
+def test_deserialize_list_none():
+    # regression for #131: the Xero API can return null for a list field
+    # (e.g. "LeaveApplications": None); deserializing must not raise.
+    result = deserialize_list("list[number]", None, model_finder=None)
+    assert result is None
+
+
 # deserialize_int tests
 @pytest.mark.parametrize("data,expected", [(n, int(n)) for n in ("1", "-1", 2)])
 def test_deserialize_int(data, expected):

--- a/xero_python/api_client/deserializer.py
+++ b/xero_python/api_client/deserializer.py
@@ -70,6 +70,8 @@ def deserialize_list(data_type, data, model_finder):
     :return: deserialized list
 
     """
+    if data is None:
+        return None
     try:
         sub_data_type = LIST_DATA_TYPE.match(data_type).group(1)
     except AttributeError:


### PR DESCRIPTION
## Fixes #131

Some Xero API responses return `null` for a field typed as an array. For example `payroll_au_api.reject_leave_application(...)` responds with:

```json
{"Id": "...", "Status": "OK", "LeaveApplications": null}
```

Deserializing this raises:

```
TypeError: 'NoneType' object is not iterable
```

because `deserialize_list` does `[deserialize(...) for sub_data in data]` without guarding against `data is None`.

### Change
Return `None` early when `data is None`, faithfully representing the null field. This mirrors `deserialize_model`, which already special-cases a `None` payload.

```python
def deserialize_list(data_type, data, model_finder):
    if data is None:
        return None
    ...
```

### Test
Added `test_deserialize_list_none`. It fails on `master` (TypeError) and passes with the fix. Full `test_api_client` suite (148 tests) stays green.