### PR TITLE
Convert MS-format datetimes without platform-bound fromtimestamp (#59)

### DIFF
--- a/tests/test_api_client/test_deserializer.py
+++ b/tests/test_api_client/test_deserializer.py
@@ -327,6 +327,25 @@ def test_deserialize_datetime_ms_error(data):
         deserialize_datetime_ms(data_type, data, model_finder=None)
 
 
+def test_deserialize_datetime_ms_pre_epoch():
+    # regression for #59: a timestamp before 1970 (negative ms) must convert
+    # cleanly on every platform instead of leaking OSError (datetime.fromtimestamp
+    # rejects negative timestamps on Windows).
+    result = deserialize_datetime_ms(
+        "datetime[ms-format]", "/Date(-2208988800000)/", model_finder=None
+    )
+    assert result == datetime(1900, 1, 1, tzinfo=tz.UTC)
+
+
+def test_deserialize_datetime_ms_out_of_range_raises_value_error():
+    # regression for #59: an out-of-range timestamp must raise the documented
+    # ValueError, not leak OSError / OverflowError from the platform C library.
+    with pytest.raises(ValueError):
+        deserialize_datetime_ms(
+            "datetime[ms-format]", "/Date(67768036191676800000)/", model_finder=None
+        )
+
+
 # deserialize_model tests
 def test_deserialize_model():
     # given test model and test data

--- a/xero_python/api_client/deserializer.py
+++ b/xero_python/api_client/deserializer.py
@@ -250,8 +250,17 @@ def deserialize_datetime_ms(data_type, data, model_finder):
             tz_info = tz.UTC
 
         timestamp_ms = int(match.groupdict()["timestamp"])
-        timestamp_s = timestamp_ms / 1000
-        return datetime.datetime.fromtimestamp(timestamp_s, tz=tz_info)
+        # datetime.fromtimestamp is bounded by the platform's C library and
+        # leaks OSError/OverflowError for out-of-range or (on Windows)
+        # pre-1970 timestamps. Build the datetime from the epoch instead so
+        # the conversion is platform independent, and surface the documented
+        # ValueError for values python's datetime cannot represent.
+        epoch = datetime.datetime(1970, 1, 1, tzinfo=tz.UTC)
+        try:
+            utc_datetime = epoch + datetime.timedelta(milliseconds=timestamp_ms)
+        except (OverflowError, OSError) as error:
+            raise ValueError("Invalid datetime value {!r}".format(data)) from error
+        return utc_datetime.astimezone(tz_info)
     elif DATE_WITH_NO_DAY_RE.match(str(data)):
         return datetime.datetime.strptime(data + "-01", "%Y-%m-%d")
     else:


### PR DESCRIPTION
## Fixes #59

`get_employees` (and other calls) intermittently fail for some organisations with:

```
File .../api_client/deserializer.py, in deserialize_datetime_ms
    return datetime.datetime.fromtimestamp(timestamp_s, tz=tz_info)
OSError: [Errno 22] Invalid argument
```

`datetime.fromtimestamp` delegates to the platform C library and is not portable at the edges:
- on **Windows** it raises `OSError` for **pre-1970 (negative)** timestamps;
- for **out-of-range** timestamps it leaks `OSError` / `OverflowError` instead of the `ValueError` this function documents ("Raise ValueError if the input is well formatted but not a valid datetime").

Some Xero responses carry such `/Date(...)/` values, so the SDK raises an unexpected error type that callers can't sensibly catch.

### Change
Build the datetime from the Unix epoch with `timedelta`, which is platform independent, and coerce genuinely unrepresentable values to the documented `ValueError`:

```python
epoch = datetime.datetime(1970, 1, 1, tzinfo=tz.UTC)
try:
    utc_datetime = epoch + datetime.timedelta(milliseconds=timestamp_ms)
except (OverflowError, OSError) as error:
    raise ValueError("Invalid datetime value {!r}".format(data)) from error
return utc_datetime.astimezone(tz_info)
```

This is behaviour-preserving for all in-range values (verified against the existing `test_deserialize_datetime_ms` cases, including the `+1300` offset).

### Tests
Added to `test_deserializer.py`:
- `test_deserialize_datetime_ms_pre_epoch` — a pre-1970 timestamp now converts cleanly (this is the Windows scenario from the issue; it can't fail in Linux CI but is what users hit).
- `test_deserialize_datetime_ms_out_of_range_raises_value_error` — an out-of-range timestamp now raises the documented `ValueError`. This **fails on `master`** (leaks `OSError`) and passes with the fix.

Full `test_api_client` suite (149 tests) stays green.