### PR TITLE
test(accounting): expect updated_date_utc_string in invoice fixtures

### DIFF
--- a/tests/accounting/api/test_accounting_api.py
+++ b/tests/accounting/api/test_accounting_api.py
@@ -382,6 +382,7 @@ def test_get_invoices(sandbox_accounting_api: AccountingApi, xero_tenant_id):
                 total_tax=Decimal(0),
                 type="ACCREC",
                 updated_date_utc=datetime.datetime(2018, 11, 2, 16, 31, 30, 160000, tzinfo=tz.UTC),
+                updated_date_utc_string="2018-11-02T16:31:30Z",
             ),
             Invoice(
                 amount_credited=Decimal(0),
@@ -431,6 +432,7 @@ def test_get_invoices(sandbox_accounting_api: AccountingApi, xero_tenant_id):
                 total_tax=Decimal(6),
                 type="ACCREC",
                 updated_date_utc=datetime.datetime(2018, 11, 2, 16, 36, 32, 690000, tzinfo=tz.UTC),
+                updated_date_utc_string="2018-11-02T16:36:32Z",
             ),
             Invoice(
                 amount_credited=Decimal(0),
@@ -467,7 +469,8 @@ def test_get_invoices(sandbox_accounting_api: AccountingApi, xero_tenant_id):
                 total=Decimal(115),
                 total_tax=Decimal(15),
                 type="ACCREC",
-                updated_date_utc=datetime.datetime(2018, 11, 2, 16, 37, 28, 927000, tzinfo=tz.UTC)
+                updated_date_utc=datetime.datetime(2018, 11, 2, 16, 37, 28, 927000, tzinfo=tz.UTC),
+                updated_date_utc_string="2018-11-02T16:37:28Z"
             )
         ],
         pagination= Pagination(
@@ -629,6 +632,7 @@ def test_update_or_create_invoices(
                 updated_date_utc=datetime.datetime(
                     2019, 3, 11, 17, 58, 46, 117000, tzinfo=tz.UTC
                 ),
+                updated_date_utc_string="2019-03-11T17:58:46Z",
             )
         ]
     )


### PR DESCRIPTION
(PETOSS-975)

Adds the new updated_date_utc_string field to the expected invoice fixtures in tests/accounting/api/test_accounting_api.py  4 invoice objects across 2 tests (test_get_invoices ×3, test_update_or_create_invoices ×1). Test-only; no SDK/runtime code changes.

Why
The Accounting API is gaining UpdatedDateUTCString — a plain ISO-8601 string mirror of the existing UpdatedDateUTC (which serialises in the legacy /Date(…)/ format), added to support the new Prepayments/Overpayments webhooks ([PETOSS-975], monolith [Xero#26503], spec [[XeroAPI/Xero-OpenAPI#823](https://github.com/XeroAPI/Xero-OpenAPI/issues/823)]).

The codegen-python gate regenerates this SDK from the OAS PR, boots a Prism mock off the response examples, and runs pytest with strict full-object equality (str(result) == str(expected)). The regenerated model now deserialises the field, but these hand-written fixtures didn't set it - so it defaulted to None while the mock returns the string, failing the two tests. This patch aligns the expected values.

The values are exactly what Prism emits (ISO-8601, seconds precision, Z suffix - the field is type: string with no format: date-time, so it stays a string rather than being coerced to a datetime). Invoice-level only; the nested Contact's updated_date_utc_string stays None, which already matches the mock.