### PR TITLE
fix: tolerate unknown enum values on deserialization (#203, #205, #206)

### DIFF
--- a/tests/test_api_client/test_deserializer.py
+++ b/tests/test_api_client/test_deserializer.py
@@ -360,6 +360,44 @@ def test_deserialize_model_error(data):
         deserialize_model(Model, data, model_finder=None)
 
 
+def test_deserialize_model_tolerates_unknown_enum():
+    # A generated model whose setter rejects unknown enum values, mimicking the
+    # real SDK models (Contact.tax_number_type, LinkedTransaction...). The Xero
+    # API can return values the SDK predates, e.g. "TAXNUMBERTYPE/SSN" (#203,
+    # #205, #206) — deserialization must not crash on them.
+    class Model:
+        openapi_types = {"tax_number_type": "str"}
+        attribute_map = {"tax_number_type": "TaxNumberType"}
+        allowed_values = ["SSN", "EIN"]
+
+        def __init__(self, tax_number_type=None):
+            self._tax_number_type = None
+            if tax_number_type is not None:
+                self.tax_number_type = tax_number_type
+
+        @property
+        def tax_number_type(self):
+            return self._tax_number_type
+
+        @tax_number_type.setter
+        def tax_number_type(self, value):
+            if value and value not in self.allowed_values:
+                raise ValueError("Invalid value for `tax_number_type` ({})".format(value))
+            self._tax_number_type = value
+
+    with mock_deserialize():
+        result = deserialize_model(
+            Model, {"TaxNumberType": "TAXNUMBERTYPE/SSN"}, model_finder=None
+        )
+    # tolerated: no crash, raw value preserved for the caller
+    assert result.tax_number_type == "TAXNUMBERTYPE/SSN"
+
+    # control: a valid value still passes through the setter unchanged
+    with mock_deserialize():
+        ok = deserialize_model(Model, {"TaxNumberType": "EIN"}, model_finder=None)
+    assert ok.tax_number_type == "EIN"
+
+
 class Shape(Enum):
     """
     Test enum class to mimic Enum API model

--- a/xero_python/api_client/deserializer.py
+++ b/xero_python/api_client/deserializer.py
@@ -284,5 +284,19 @@ def deserialize_model(model, data, model_finder):
             value = data[attr_key]
             kwargs[attr] = deserialize(attr_type, value, model_finder)
 
-    instance = model(**kwargs)
+    try:
+        instance = model(**kwargs)
+    except ValueError:
+        # The Xero API can return enum values this generated SDK predates
+        # (e.g. new/unexpected tax_number_type or source_transaction_type_code
+        # values). The per-attribute setters reject those with ValueError, which
+        # otherwise crashes deserialization of an otherwise-valid response and
+        # forces callers to monkey-patch the SDK. Build the model tolerantly
+        # instead, preserving the raw value the API sent. (#203, #205, #206)
+        instance = model()
+        for attr, value in kwargs.items():
+            try:
+                setattr(instance, attr, value)
+            except ValueError:
+                setattr(instance, "_" + attr, value)
     return instance


### PR DESCRIPTION
Fixes #203, #205, #206.

The Xero API returns enum values this generated SDK predates — e.g. a contact with `TaxNumberType` = `"TAXNUMBERTYPE/SSN"` (#203, #205) or a linked transaction with `SourceTransactionTypeCode` = `"RECEIPT"` (#206). The per-attribute setters validate against a hardcoded `allowed_values` and raise `ValueError`, which crashes deserialization of an otherwise-valid API response and forces callers to monkey-patch the SDK.

`deserialize_model` now attempts the normal validating construction first — so all valid data behaves exactly as before — and only on `ValueError` falls back to building the model tolerantly, preserving the raw value the API sent (set on the private field, bypassing the setter). Deserialization shouldn't reject values the authoritative server returns.

Verified locally: both reported values reproduce the `ValueError` on `main` and deserialize cleanly after; valid values (e.g. `EIN`) are unaffected. Added `test_deserialize_model_tolerates_unknown_enum`; full deserializer suite green (63 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
