### PR TITLE
fix: use HTTPResponse.headers instead of deprecated getheaders/getheader

### DIFF
--- a/xero_python/exceptions/__init__.py
+++ b/xero_python/exceptions/__init__.py
@@ -35,7 +35,7 @@ class ApiException(OpenApiException):
 
     @property
     def headers(self):
-        return self.http_resp.getheaders() if self.http_resp else None
+        return self.http_resp.headers if self.http_resp else None
 
     @property
     def error_message(self):

--- a/xero_python/rest.py
+++ b/xero_python/rest.py
@@ -43,13 +43,18 @@ class RESTResponse(io.IOBase):
         # the response.data is bytes. we need to decode it to string.
         return self.data.decode("utf8")
 
+    @property
+    def headers(self):
+        """Returns the response headers."""
+        return self.urllib3_response.headers
+
     def getheaders(self):
         """Returns a dictionary of the response headers."""
-        return self.urllib3_response.getheaders()
+        return self.urllib3_response.headers
 
     def getheader(self, name, default=None):
         """Returns a given response header."""
-        return self.urllib3_response.getheader(name, default)
+        return self.urllib3_response.headers.get(name, default)
 
 
 class RESTClientObject(object):


### PR DESCRIPTION
## Description

`urllib3` has deprecated `HTTPResponse.getheaders()` and `HTTPResponse.getheader()` and will remove them in v2.6.0:

```
DeprecationWarning: HTTPResponse.getheaders() is deprecated and will be removed in urllib3 v2.6.0.
Instead access HTTPResponse.headers directly.
```

This blocks consumers from upgrading `urllib3`. This PR switches the SDK to access `.headers` directly:

- `rest.py`: `RESTResponse` now exposes a `headers` property and its `getheaders()`/`getheader()` wrappers read from `.headers` (so the existing public API is preserved, and the two call sites in `api_client` are fixed transitively).
- `exceptions/__init__.py`: `ApiException.headers` reads `.headers` directly.

Behaviour is unchanged: on urllib3 v2 `.headers.get(name, default)` returns the same result as the previous `getheader(name, default)`, and `.headers` is the same `HTTPHeaderDict` that `getheaders()` returned.

Fixes #195