### PR TITLE
fix: avoid deprecated urllib3 header helpers

### DIFF
--- a/tests/test_api_client/test_rest_response.py
+++ b/tests/test_api_client/test_rest_response.py
@@ -1,0 +1,23 @@
+from xero_python.rest import RESTResponse
+
+
+class DummyResponse:
+    def __init__(self):
+        self.status = 200
+        self.reason = "OK"
+        self.data = b"{}"
+        self.headers = {
+            "Content-Disposition": "attachment; filename=test.json",
+            "X-Trace-Id": "abc123",
+        }
+
+
+def test_rest_response_reads_headers_without_deprecated_urllib3_helpers():
+    response = RESTResponse(DummyResponse())
+
+    assert response.getheaders() == {
+        "Content-Disposition": "attachment; filename=test.json",
+        "X-Trace-Id": "abc123",
+    }
+    assert response.getheader("Content-Disposition") == "attachment; filename=test.json"
+    assert response.getheader("Missing", "fallback") == "fallback"

--- a/xero_python/rest.py
+++ b/xero_python/rest.py
@@ -45,11 +45,11 @@ class RESTResponse(io.IOBase):
 
     def getheaders(self):
         """Returns a dictionary of the response headers."""
-        return self.urllib3_response.getheaders()
+        return dict(self.urllib3_response.headers.items())
 
     def getheader(self, name, default=None):
         """Returns a given response header."""
-        return self.urllib3_response.getheader(name, default)
+        return self.urllib3_response.headers.get(name, default)
 
 
 class RESTClientObject(object):


### PR DESCRIPTION
## Summary
- replace deprecated urllib3 header helper calls in `RESTResponse`
- read headers through the response `headers` mapping instead
- add a focused unit test for header access

## Why
Fixes the deprecation warning reported in #195 when `getheader()` and `getheaders()` are called.

## Testing
- `python -m pytest tests/test_api_client/test_rest_response.py`